### PR TITLE
Fix import paths case

### DIFF
--- a/Source/Interface/modular_screen.lua
+++ b/Source/Interface/modular_screen.lua
@@ -96,8 +96,8 @@ import 'Modules/Synths/StochasticSquare/stochastic_square_mod'
 import 'Modules/Synths/StochasticSine/stochastic_sine_mod'
 import 'Modules/Synths/OrlSynth/synth_mod'
 import 'Modules/Synths/OrlSampleSynth/sample_synth_mod'
-import 'Modules/Synths/WavetableSynth/wavetable_synth_mod'
-import 'Modules/Synths/WavetableSynth2D/wavetable_synth2d_mod'
+import 'Modules/Synths/WaveTableSynth/wavetable_synth_mod'
+import 'Modules/Synths/WaveTableSynth2D/wavetable_synth2d_mod'
 import 'Modules/Synths/WavetableHz/wavetable_hz_mod'
 
 print("ModularScreen import: modules synths done")
@@ -141,7 +141,7 @@ print("ModularScreen import: modules ui done")
 
 import 'Modules/Serial/SerialMidiNoteInput/serial_in_mod'
 import 'Modules/Serial/SerialClockInput/serial_clock_mod'
-import 'Modules/Serial/Serialbang/serial_bang_mod'
+import 'Modules/Serial/SerialBang/serial_bang_mod'
 
 print("ModularScreen import: modules pedal and serial in done")
 

--- a/Source/Modules/Mixers/Mixer1/mix1_mod.lua
+++ b/Source/Modules/Mixers/Mixer1/mix1_mod.lua
@@ -2,7 +2,7 @@
 	© 2023 Orllewin - All Rights Reserved.
 ]]
 import 'Modules/mod_utils.lua'
-import 'Modules/sprites/small_socket_sprite'
+import 'Modules/Sprites/small_socket_sprite'
 
 class('Mix1Mod').extends(playdate.graphics.sprite)
 

--- a/Source/Modules/Mixers/Mixer1v2/mix1v2_mod.lua
+++ b/Source/Modules/Mixers/Mixer1v2/mix1v2_mod.lua
@@ -2,7 +2,7 @@
 	© 2023 Orllewin - All Rights Reserved.
 ]]
 import 'Modules/mod_utils.lua'
-import 'Modules/sprites/small_socket_sprite'
+import 'Modules/Sprites/small_socket_sprite'
 
 class('Mix1v2Mod').extends(playdate.graphics.sprite)
 

--- a/Source/Modules/Pedals/HighPass/highpass_mod.lua
+++ b/Source/Modules/Pedals/HighPass/highpass_mod.lua
@@ -2,7 +2,7 @@
 	© 2023 Orllewin - All Rights Reserved.
 ]]
 import 'Modules/mod_utils.lua'
-import 'Modules/Pedals/Highpass/highpass_component'
+import 'Modules/Pedals/HighPass/highpass_component'
 import 'Modules/mod_about_popup'
 import 'Modules/module_menu'
 import 'Coracle/math'

--- a/Source/Modules/Pedals/LowPass/lowpass_mod.lua
+++ b/Source/Modules/Pedals/LowPass/lowpass_mod.lua
@@ -3,7 +3,7 @@
 ]]
 
 import 'Modules/mod_utils.lua'
-import 'Modules/Pedals/Lowpass/lowpass_component'
+import 'Modules/Pedals/LowPass/lowpass_component'
 import 'Modules/mod_about_popup'
 import 'Modules/module_menu'
 import 'Coracle/math'

--- a/Source/Modules/Synths/WaveTableSynth/wavetable_synth_mod.lua
+++ b/Source/Modules/Synths/WaveTableSynth/wavetable_synth_mod.lua
@@ -2,7 +2,7 @@
 	© 2023 Orllewin - All Rights Reserved.
 ]]--
 import 'Modules/mod_utils.lua'
-import 'Modules/Synths/WavetableSynth/wavetable_synth_component'
+import 'Modules/Synths/WaveTableSynth/wavetable_synth_component'
 
 class('WavetableSynthMod').extends(playdate.graphics.sprite)
 

--- a/Source/Modules/Synths/WaveTableSynth2D/wavetable_synth2d_mod.lua
+++ b/Source/Modules/Synths/WaveTableSynth2D/wavetable_synth2d_mod.lua
@@ -2,7 +2,7 @@
 	© 2023 Orllewin - All Rights Reserved.
 ]]--
 import 'Modules/mod_utils.lua'
-import 'Modules/Synths/WavetableSynth2D/wavetable_synth2d_component'
+import 'Modules/Synths/WaveTableSynth2D/wavetable_synth2d_component'
 
 class('WavetableSynth2DMod').extends(playdate.graphics.sprite)
 

--- a/Source/main.lua
+++ b/Source/main.lua
@@ -70,8 +70,8 @@ print("> import: value generator modules done")
 -- Modules - Pedals (mostly effects)
 import 'Modules/Pedals/Bitcrusher/bitcrusher_mod'
 import 'Modules/Pedals/Delay/delay_mod'
-import 'Modules/Pedals/Highpass/highpass_mod'
-import 'Modules/Pedals/Lowpass/lowpass_mod'
+import 'Modules/Pedals/HighPass/highpass_mod'
+import 'Modules/Pedals/LowPass/lowpass_mod'
 import 'Modules/Pedals/OnePoleFilter/one_pole_filter_mod'
 import 'Modules/Pedals/Overdrive/overdrive_mod'
 import 'Modules/Pedals/RingModulator/ring_modulator_mod'


### PR DESCRIPTION
I tried compiling the app on linux and I got many import errors because of modules not found
They all seem to be because of wrong case like `Highpass` vs `HighPass`
I modified the imports until I got no errors and managed to compile it

I don't have experience with playdate development so I might have done something wrong, but if not I thought you might find the fix useful

